### PR TITLE
reworking container use episode

### DIFF
--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -5,16 +5,20 @@ exercises: 10
 questions:
 - "How do I interact with a Docker container on my computer?"
 objectives:
+- "Use the correct command to see which Docker images are on your computer."
+- "Download new Docker images."
 - "Demonstrate how to start an instance of a container from an image."
-- "Explain how to list (container) images on your laptop."
+- "Describe at least two ways to run commands inside a running Docker container."
 keypoints:
-- "Containers are usually started using command line invocations."
-- "The `docker run` command creates containers from images and can run commands inside them."
-- "The `docker image` command lists images that are (now) on your computer."
+- "The `docker pull` command downloads Docker images from the internet."
+- "The `docker image` command lists Docker images that are (now) on your computer."
+- "The `docker run` command creates running containers from images and can run commands inside them."
+- "When using the `docker run` command, a container can run a default action (if it
+has one), a user specified action, or a shell to be used interactively."
 ---
 
 > ## Reminder of terminology: images and containers
-> - Recall that a container "image" is the template from which particular instances of containers will be created.
+> Recall that a container "image" is the template from which particular instances of containers will be created.
 {: .callout}
 
 Let's explore our first Docker container. The Docker team provides a simple container
@@ -110,7 +114,7 @@ For more examples and ideas, visit:
 ~~~
 {: .output}
 
-What just happened? When we use the `docker run` command, Docker:
+What just happened? When we use the `docker run` command, Docker does three things:
 
 | 1. Starts a Running Container | 2. Performs Default Action | 3. Shuts Down the Container
 | --------------------|-----------------|----------------|
@@ -131,19 +135,21 @@ namely to print this message.
 ## Running a container with a chosen command
 
 But what if we wanted to do something different with the container? The output
-just gave us a suggestion of what to do -- let's use the `ubuntu` Docker image
-to explore what else we can do with the `docker run` command.
+just gave us a suggestion of what to do -- let's use a different Docker image
+to explore what else we can do with the `docker run` command. The suggestion above
+is to use `ubuntu`, but we're going to run a different type of Linux, `alpine`
+instead because it's quicker to download.
 
-> ## Run the Ubuntu Docker container
+> ## Run the Alpine Docker container
 >
-> Try downloading and running the `ubuntu` Docker container. You can do it in
+> Try downloading and running the `alpine` Docker container. You can do it in
 > two steps, or one. What are they?
 {: .callout}
 
 What happened when you ran the Ubuntu Docker container?
 
 ~~~
-$ docker run ubuntu
+$ docker run alpine
 ~~~
 {: .language-bash}
 
@@ -151,9 +157,12 @@ Probably nothing! That's because this particular container is designed for you t
 provide commands yourself. Try running this instead:
 
 ~~~
-$ docker run ubuntu cat /etc/os_release
+$ docker run alpine cat /proc/version
 ~~~
 {: .language-bash}
+
+You should see the output of the `cat /proc/version` command, which prints out
+the version of Linux that this container is using.
 
 > ## Exercise
 > Can you run the container and make it print a "hello world" message?
@@ -162,9 +171,9 @@ $ docker run ubuntu cat /etc/os_release
 >
 > > ## Solution
 > >
-> > To see if the `hello-world` image is now on your computer, run:
+> > Use the same command as above, but with the `echo` command to print a message.
 > > ~~~
-> > $ docker run ubuntu echo 'Hello World'
+> > $ docker run alpine echo 'Hello World'
 > > ~~~
 > > {: .language-bash}
 > {: .solution}
@@ -177,18 +186,18 @@ command and they will execute inside the running container.
 
 In all the examples above, Docker has started the container, run a command, and then
 immediately shut down the container. But what if we wanted to keep the container
-running for awhile so we could log into it and test drive more commands? The way to
+running so we could log into it and test drive more commands? The way to
 do this is by adding the interactive flag `-it` to the `docker run` command and
-by providing a shell (usually `bash`) as our command.
+by providing a shell (usually `bash` or `sh`) as our command.
 
 ~~~
-$ docker run -it ubuntu bash
+$ docker run -it alpine sh
 ~~~
 {: .language-bash}
 
 Your prompt should change significantly to look like this:
 ~~~
-root@2d8d37405cc1:/#
+/ #
 ~~~
 {: .language-bash}
 
@@ -198,13 +207,14 @@ That's because you're now inside the running container! Try these commands:
 * `ls`
 * `whoami`
 * `echo $PATH`
-* `cat /etc/os_release`
+* `cat /proc/version`
 
 All of these are being run from inside the running container, so you'll get information
-about the container itself, instead of your computer.
+about the container itself, instead of your computer. To finish using the container,
+just type `exit`.
 
 ~~~
-lkdjf;alskdfj;lak? exit
+/ # exit
 ~~~
 {: .language-bash}
 

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -55,7 +55,7 @@ docker.io/library/hello-world:latest
 
 > ## DockerHub
 >
-> Where did the `hello-world` image come from? Technically, it came from the DockerHub
+> Where did the `hello-world` image come from? It came from the DockerHub
 > website, which is a place to share Docker images with other people. More on that
 > in a later episode.
 {: .callout}
@@ -125,7 +125,7 @@ namely to print this message.
 
 > ## Using `docker run` to get the image
 >
-> Technically, we could have skipped the `docker pull` step; if you use the `docker run`
+> We could have skipped the `docker pull` step; if you use the `docker run`
 > command and you don't already have a copy of the Docker image, Docker will
 > automatically pull the image first and then run it.
 {: .callout}
@@ -142,7 +142,7 @@ instead because it's quicker to download.
 >
 > Try downloading and running the `alpine` Docker container. You can do it in
 > two steps, or one. What are they?
-{: .callout}
+{: .challenge}
 
 What happened when you ran the Ubuntu Docker container?
 
@@ -162,7 +162,7 @@ $ docker run alpine cat /proc/version
 You should see the output of the `cat /proc/version` command, which prints out
 the version of Linux that this container is using.
 
-> ## Exercise
+> ## Hello World, Part 2
 > Can you run the container and make it print a "hello world" message?
 >
 > Give it a try before checking the solution.
@@ -193,6 +193,15 @@ $ docker run -it alpine sh
 ~~~
 {: .language-bash}
 
+> ## Technically...
+>
+> Technically, the interactive flag is just `-i`, the extra `-t` (combined
+> as `-it` above) is an option that allows you to connect to a shell like
+> bash. But since usually you want to have a command line when run interactively,
+> it always makes sense to use the two together.
+{: .callout}
+
+
 Your prompt should change significantly to look like this:
 ~~~
 / #
@@ -215,6 +224,51 @@ just type `exit`.
 / # exit
 ~~~
 {: .language-bash}
+
+> ## Practice Makes Perfect
+> Can you find out the version of Linux installed on the `busybox` container?
+> Can you find the `busybox` program? What does it do? (Hint: passing `--help`
+> to almost any command will give you more information.)
+>
+> > ## Solution 1 - Interactive
+> >
+> > Run the busybox container interactively -- you can use `docker pull` first, or just
+> > run it with this command:
+> > ~~~
+> > $ docker run -it busybox sh
+> > ~~~
+> > {: .language-bash}
+> >
+> > Then try, running these commands
+> >
+> > ~~~
+> > /# cat /proc/version
+> > /# busybox --help
+> > ~~~
+> > {: .language-bash}
+> >
+> > Exit when you're done.
+> > ~~~
+> > /# exit
+> > ~~~
+> > {: .language-bash}
+> {: .solution}
+>
+> > ## Solution 2 - Run commands
+> >
+> > Run the busybox container, first with a command to read out the Linux version:
+> > ~~~
+> > $ docker run busybox cat /proc/version
+> > ~~~
+> > {: .language-bash}
+> >
+> > Then run the container again with a command to print out the busybox help:
+> > ~~~
+> > $ docker run busybox busybox --help
+> > ~~~
+> > {: .language-bash}
+> {: .solution}
+{: .challenge}
 
 ## Conclusion
 

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -1,20 +1,17 @@
 ---
 title: "Exploring and Running Containers"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "How do I interact with a Docker container on my computer?"
 objectives:
-- "Demonstrate how to create an instance of a container from an image."
+- "Demonstrate how to start an instance of a container from an image."
 - "Explain how to list (container) images on your laptop."
-- "Explain how to list running and completed containers."
 keypoints:
-- "Containers are usually created using command line invocations."
-- "The `docker run` command creates containers from images."
+- "Containers are usually started using command line invocations."
+- "The `docker run` command creates containers from images and can run commands inside them."
 - "The `docker image` command lists images that are (now) on your computer."
-- "The `docker container` command lists containers that have been created."
 ---
-
 
 > ## Reminder of terminology: images and containers
 > - Recall that a container "image" is the template from which particular instances of containers will be created.
@@ -84,6 +81,7 @@ computer.
 ## Running the `hello-world` container
 
 To create and run containers from named Docker images you use the `docker run` command. Try the following `docker run` invocation. Note that it does not matter what your current working directory is.
+
 ~~~
 $ docker run hello-world
 ~~~
@@ -112,8 +110,7 @@ For more examples and ideas, visit:
 ~~~
 {: .output}
 
-What just happened? The `hello-world` container is set up to run an action by default -
-namely to print this message. When we use the `docker run` command, Docker:
+What just happened? When we use the `docker run` command, Docker:
 
 | 1. Starts a Running Container | 2. Performs Default Action | 3. Shuts Down the Container
 | --------------------|-----------------|----------------|
@@ -121,7 +118,10 @@ namely to print this message. When we use the `docker run` command, Docker:
 "inflated" version of the container -- it's actually doing something | If the container has a default action set, it will perform that default action. This could be as simple as printing a message (as above) or running a whole analysis pipeline! | Once the default action is complete, the container stops running (or exits). The image
 is still there, but nothing is actively running. |
 
-> ## docker run
+The `hello-world` container is set up to run an action by default -
+namely to print this message.
+
+> ## Using `docker run` to get the image
 >
 > Technically, we could have skipped the `docker pull` step; if you use the `docker run`
 > command and you don't already have a copy of the Docker image, Docker will
@@ -130,7 +130,7 @@ is still there, but nothing is actively running. |
 
 ## Running a container with a chosen command
 
-But what if we wanted to do something different? The output
+But what if we wanted to do something different with the container? The output
 just gave us a suggestion of what to do -- let's use the `ubuntu` Docker image
 to explore what else we can do with the `docker run` command.
 
@@ -148,20 +148,27 @@ $ docker run ubuntu
 {: .language-bash}
 
 Probably nothing! That's because this particular container is designed for you to
-provide commands. Try running this instead:
+provide commands yourself. Try running this instead:
 
 ~~~
 $ docker run ubuntu cat /etc/os_release
 ~~~
 {: .language-bash}
 
-## Exercise
-Can you run the container and make it print a "hello world" message.
-
-~~~
-$ docker run ubuntu echo 'Hello World'
-~~~
-{: .language-bash}
+> ## Exercise
+> Can you run the container and make it print a "hello world" message?
+>
+> Give it a try before checking the solution.
+>
+> > ## Solution
+> >
+> > To see if the `hello-world` image is now on your computer, run:
+> > ~~~
+> > $ docker run ubuntu echo 'Hello World'
+> > ~~~
+> > {: .language-bash}
+> {: .solution}
+{: .challenge}
 
 So here, we see another option -- we can provide commands at the end of the `docker run`
 command and they will execute inside the running container.

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -118,9 +118,7 @@ What just happened? When we use the `docker run` command, Docker does three thin
 
 | 1. Starts a Running Container | 2. Performs Default Action | 3. Shuts Down the Container
 | --------------------|-----------------|----------------|
-| starts a running container, based on the image. Think of this as the "alive" or
-"inflated" version of the container -- it's actually doing something | If the container has a default action set, it will perform that default action. This could be as simple as printing a message (as above) or running a whole analysis pipeline! | Once the default action is complete, the container stops running (or exits). The image
-is still there, but nothing is actively running. |
+| starts a running container, based on the image. Think of this as the "alive" or"inflated" version of the container -- it's actually doing something | If the container has a default action set, it will perform that default action. This could be as simple as printing a message (as above) or running a whole analysis pipeline! | Once the default action is complete, the container stops running (or exits). The image is still there, but nothing is actively running. |
 
 The `hello-world` container is set up to run an action by default -
 namely to print this message.

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -1,0 +1,217 @@
+---
+title: "Exploring and Running Containers"
+teaching: 10
+exercises: 0
+questions:
+- "How do I interact with a Docker container on my computer?"
+objectives:
+- "Demonstrate how to create an instance of a container from an image."
+- "Explain how to list (container) images on your laptop."
+- "Explain how to list running and completed containers."
+keypoints:
+- "Containers are usually created using command line invocations."
+- "The `docker run` command creates containers from images."
+- "The `docker image` command lists images that are (now) on your computer."
+- "The `docker container` command lists containers that have been created."
+---
+
+
+> ## Reminder of terminology: images and containers
+> - Recall that a container "image" is the template from which particular instances of containers will be created.
+{: .callout}
+
+Let's explore our first Docker container. The Docker team provides a simple container
+image online called `hello-world`. We'll start with that one.
+
+## Downloading Docker images
+
+The `docker image` command is used to list and modify Docker images.
+You can find out what container images you have on your computer by using the following command ("ls" is short for "list"):
+~~~
+$ docker image ls
+~~~
+{: .language-bash}
+
+If you've just
+installed Docker, you won't see any images listed.
+
+To get a copy of the `hello-world` Docker image from the internet, run this command:
+~~~
+$ docker pull hello-world
+~~~
+{: .language-bash}
+
+You should see output like this:
+~~~
+Using default tag: latest
+latest: Pulling from library/hello-world
+1b930d010525: Pull complete
+Digest: sha256:f9dfddf63636d84ef479d645ab5885156ae030f611a56f3a7ac7f2fdd86d7e4e
+Status: Downloaded newer image for hello-world:latest
+docker.io/library/hello-world:latest
+~~~
+{: .output}
+
+> ## DockerHub
+>
+> Where did the `hello-world` image come from? Technically, it came from the DockerHub
+> website, which is a place to share Docker images with other people. More on that
+> in a later episode.
+{: .callout}
+
+> ## Exercise: Check on Your Images
+>
+> What command would you use to see if the `hello-world` Docker image had downloaded
+> successfully and was on your computer?
+> Give it a try before checking the solution.
+>
+> > ## Solution
+> >
+> > To see if the `hello-world` image is now on your computer, run:
+> > ~~~
+> > $ docker image ls
+> > ~~~
+> > {: .language-bash}
+> {: .solution}
+{: .challenge}
+
+Note that the downloaded `hello-world` image is not in the folder where you are in the terminal! (Run
+`ls` by itself to check.) The image is not a file like our normal programs and files;
+Docker stores it in a specific location that isn't commonly accessed, so it's necessary
+to use the special `docker image` command to see what Docker images you have on your
+computer.
+
+## Running the `hello-world` container
+
+To create and run containers from named Docker images you use the `docker run` command. Try the following `docker run` invocation. Note that it does not matter what your current working directory is.
+~~~
+$ docker run hello-world
+~~~
+{: .language-bash}
+~~~
+Hello from Docker!
+This message shows that your installation appears to be working correctly.
+
+To generate this message, Docker took the following steps:
+ 1. The Docker client contacted the Docker daemon.
+ 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+    (amd64)
+ 3. The Docker daemon created a new container from that image which runs the
+    executable that produces the output you are currently reading.
+ 4. The Docker daemon streamed that output to the Docker client, which sent it
+    to your terminal.
+
+To try something more ambitious, you can run an Ubuntu container with:
+ $ docker run -it ubuntu bash
+
+Share images, automate workflows, and more with a free Docker ID:
+ https://hub.docker.com/
+
+For more examples and ideas, visit:
+ https://docs.docker.com/get-started/
+~~~
+{: .output}
+
+What just happened? The `hello-world` container is set up to run an action by default -
+namely to print this message. When we use the `docker run` command, Docker:
+
+| 1. Starts a Running Container | 2. Performs Default Action | 3. Shuts Down the Container
+| --------------------|-----------------|----------------|
+| starts a running container, based on the image. Think of this as the "alive" or
+"inflated" version of the container -- it's actually doing something | If the container has a default action set, it will perform that default action. This could be as simple as printing a message (as above) or running a whole analysis pipeline! | Once the default action is complete, the container stops running (or exits). The image
+is still there, but nothing is actively running. |
+
+> ## docker run
+>
+> Technically, we could have skipped the `docker pull` step; if you use the `docker run`
+> command and you don't already have a copy of the Docker image, Docker will
+> automatically pull the image first and then run it.
+{: .callout}
+
+## Running a container with a chosen command
+
+But what if we wanted to do something different? The output
+just gave us a suggestion of what to do -- let's use the `ubuntu` Docker image
+to explore what else we can do with the `docker run` command.
+
+> ## Run the Ubuntu Docker container
+>
+> Try downloading and running the `ubuntu` Docker container. You can do it in
+> two steps, or one. What are they?
+{: .callout}
+
+What happened when you ran the Ubuntu Docker container?
+
+~~~
+$ docker run ubuntu
+~~~
+{: .language-bash}
+
+Probably nothing! That's because this particular container is designed for you to
+provide commands. Try running this instead:
+
+~~~
+$ docker run ubuntu cat /etc/os_release
+~~~
+{: .language-bash}
+
+## Exercise
+Can you run the container and make it print a "hello world" message.
+
+~~~
+$ docker run ubuntu echo 'Hello World'
+~~~
+{: .language-bash}
+
+So here, we see another option -- we can provide commands at the end of the `docker run`
+command and they will execute inside the running container.
+
+## Running containers interactively
+
+In all the examples above, Docker has started the container, run a command, and then
+immediately shut down the container. But what if we wanted to keep the container
+running for awhile so we could log into it and test drive more commands? The way to
+do this is by adding the interactive flag `-it` to the `docker run` command and
+by providing a shell (usually `bash`) as our command.
+
+~~~
+$ docker run -it ubuntu bash
+~~~
+{: .language-bash}
+
+Your prompt should change significantly to look like this:
+~~~
+root@2d8d37405cc1:/#
+~~~
+{: .language-bash}
+
+That's because you're now inside the running container! Try these commands:
+
+* `pwd`
+* `ls`
+* `whoami`
+* `echo $PATH`
+* `cat /etc/os_release`
+
+All of these are being run from inside the running container, so you'll get information
+about the container itself, instead of your computer.
+
+~~~
+lkdjf;alskdfj;lak? exit
+~~~
+{: .language-bash}
+
+## Conclusion
+
+So far, we've seen how to download Docker images, use them to run commands inside
+running containers, and even how to explore a running container from the inside.
+Next, we'll take a closer look at all the different kinds of Docker images that are out there.
+
+{% include links.md %}
+
+{% comment %}
+<!--  LocalWords:  keypoints amd64 fce289e99eb9 zen_dubinsky links.md
+ -->
+<!--  LocalWords:  eager_engelbart endcomment
+ -->
+{% endcomment %}

--- a/_episodes/04b-managing-containers.md
+++ b/_episodes/04b-managing-containers.md
@@ -1,109 +1,58 @@
 ---
-title: "Exploring and Running Containers"
+title: "Cleaning Up Containers"
 teaching: 10
 exercises: 0
 questions:
 - "How do I interact with a Docker container on my computer?"
 objectives:
-- "Demonstrate how to create an instance of a container from an image."
-- "Explain how to list (container) images on your laptop."
 - "Explain how to list running and completed containers."
 keypoints:
-- "Containers are usually created using command line invocations."
-- "The `docker run` command creates containers from images."
-- "The `docker image` command lists images that are (now) on your computer."
 - "The `docker container` command lists containers that have been created."
 ---
 
+## Removing images
 
-If you need to reclaim space, you will need to remove image files.
-On macOS and Windows, when you uninstall the overall Docker software, it should have the effect of removing all of your image files, although I have not explicitly tested this.
+The images and their corresponding containers can start to take up a lot of disk space if you don't clean them up occasionally, so it's a good idea to periodically remove container images that you won't be using anymore.
 
-### Removing images
-If you want to explicitly remove a container image, you will need to find out details such as the "image ID". For example say my laptop contained the following image.
+In order to remove a specific image, you need to find out details about the image,
+specifically, the "image ID". For example say my laptop contained the following image.
 ~~~
 $ docker image ls
 ~~~
 {: .language-bash}
 ~~~
-REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
-ubuntu                 trusty              dc4491992653        12 months ago       222MB
+REPOSITORY       TAG         IMAGE ID       CREATED          SIZE
+hello-world      latest      fce289e99eb9   15 months ago    1.84kB
 ~~~
 {: .output}
 
-I can remove the image with a `docker image rm` command that includes the image ID, such as:
+You can remove the image with a `docker image rm` command that includes the image ID, such as:
 ~~~
-$ docker image rm dc4491992653
-~~~
-{: .language-bash}
-~~~
-Untagged: ubuntu:trusty
-Untagged: ubuntu@sha256:e1c8bff470c771c6e86d3166607e2c74e6986b05bf339784a9cab70e0e03c7c3
-Deleted: sha256:dc4491992653ecf02ae2d0e9d3dbdaab63af8ccdcab87ee0ee7e532f7087dd73
-Deleted: sha256:1239c33230909cc231da97b851df65e252dc9811dcee2af0ecf3b225e2805a31
-Deleted: sha256:ce4caf69568d9109febd1f5307b62d85ab84e7a947fded041be49c847b412e5a
-Deleted: sha256:4c711cc0452303f0fb6ce885c84130e32bb649b03f690fd0e4626a874b1cc8cf
-Deleted: sha256:a375921af0e34b1cb09a35af24265db01b1eb65edabadaf70d56505a60a6de2b
-Deleted: sha256:c41b9462ea4bbc2f578e42bd915214d54948d960b9b8c6815daf8586811c2d38
-~~~
-{: .output}
-
-The reason that there is so much output, is that a given image may be created by merging multiple underlying layers. Any layers that are used by multiple Docker images will only be stored once.
-
-### What containers are running?
-The command to list the containers that are currently running is
-~~~
-docker container ls
+$ docker image rm fce289e99eb9
 ~~~
 {: .language-bash}
 
-... although the output should be blank, since the instances of hello-world containers will have been wiped away as soon as they completed. However the container image remains on your computer so that it is quick for you to create future such instances of hello-world containers.
-
-### What containers have run recently?
-There is also a way to list running containers, and those that have completed recently, which is to add the `--all` flag to the `docker container ls` command as shown below.
-~~~
-$ docker container ls --all
-~~~
-{: .language-bash}
-~~~
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                     PORTS               NAMES
-9c698655416a        hello-world         "/hello"            2 minutes ago       Exited (0) 2 minutes ago                       zen_dubinsky
-6dd822cf6ca9        hello-world         "/hello"            3 minutes ago       Exited (0) 3 minutes ago                       eager_engelbart
-~~~
-{: .output}
-
-### Removing images
-
-If you need to reclaim disk space, you can remove image files.
-The images and their corresponding containers can start to take up a lot of disk space if you don't clean them up occasionally.
-On macOS and Windows, when you uninstall the overall Docker software, it should have the effect of removing all of your image files, although we have not explicitly tested this.
-
-If you want to explicitly remove a container image, you will need to find out details such as the "image ID" or name of the repository. For example say my laptop contained the following image.
-~~~
-$ docker image ls
-~~~
-{: .language-bash}
-~~~
-REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
-ubuntu                 trusty              dc4491992653        12 months ago       222MB
-hello-world            latest              fce289e99eb9        4 months ago        1.84kB
-~~~
-{: .output}
-
-We can try to remove remove the `hello-world` image with a `docker image rm` command that includes the repository name, like so but...:
+or use the image name, like so:
 ~~~
 $ docker image rm hello-world
 ~~~
 {: .language-bash}
+
+However, you may see this output:
 ~~~
 Error response from daemon: conflict: unable to remove repository reference "hello-world" (must force) - container e7d3b76b00f4 is using its referenced image fce289e99eb9
 ~~~
 {: .output}
-We get this error because there are containers created that depend on this image.
 
-### What containers are running?
-As indicated by the error above there is still an existing container from this image.
-We can list the running containers by typing.
+This happens when Docker hasn't cleaned up some of the times when a container
+has been actually run. So before removing the container image, we need to be able
+to see what containers are currently running, or have been run recently, and how
+to remove these.
+
+## What containers are running?
+
+Working with containers, we are going to shift to a new docker command: `docker container`.  Similar to `docker image`, we can list running containers by typing:
+
 ~~~
 $ docker container ls
 ~~~
@@ -113,12 +62,17 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 ~~~
 {: .output}
 
-The first version of the command is orthogonal to what we know from the Unix shell but we might want to use the shorter version. For reference, "ps" stands for “Process Status”.
-We should also notice that this command didn't return any containers because our containers all exited and thus stopped running after they completed their work.
+Notice that this command didn't return any containers because our containers all exited and thus stopped running after they completed their work.
 
+> ## `docker ps`
+>
+> The command `docker ps` serves the same purpose as `docker container ls`, and comes
+> from the Unix shell command `ps` which describes running processes.
+{: .callout}
 
-### What containers have run recently?
-There is also a way to list running containers, and those that have completed recently, which is to add the `--all`/`-a` flag to the `docker container ls`/`docker ps` command as shown below.
+## What containers have run recently?
+
+There is also a way to list running containers, and those that have completed recently, which is to add the `--all`/`-a` flag to the `docker container ls` command as shown below.
 ~~~
 $ docker container ls --all
 ~~~
@@ -130,12 +84,19 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 ~~~
 {: .output}
 
-We will talk more about how you might use these exited containers and how to restart a container later in this lesson.
+> ## Keeping it clean
+>
+> You might be surprised at the number of containers Docker is still keeping track of.
+> One way to prevent this from happening is to add the `--rm` flag to `docker run`. This
+> will completely wipe out the record of the run container when it exits. If you need
+> a reference to the running container for any reason, **don't** use this flag.
+{: .callout}
 
+## How do I remove an exited container?
 
-### How do I remove an exited container?
 To delete an exited container you can run the following command, inserting the `CONTAINER ID` for the container you wish to remove.
 It will repeat the `CONTAINER ID` back to you, if successful.
+
 ~~~
 $ docker container rm 9c698655416a
 ~~~
@@ -163,7 +124,10 @@ Deleted Containers:
 ~~~
 {: .output}
 
-### Removing images, for real this time
+## Removing images, for real this time
+
+Now that we've removed any potentially running containers, we can try again to
+delete the `hello-world` **image**.
 
 ~~~
 $ docker image rm hello-world
@@ -179,19 +143,7 @@ Deleted: sha256:af0b15c8625bb1938f1d7b17081031f649fd14e6b233688eea3c5483994a66a3
 
 The reason that there are a few lines of output, is that a given image may have been formed by merging multiple underlying layers.
 Any layers that are used by multiple Docker images will only be stored once.
-Now the result of `docker images` should no longer include the `hello-world` image.
-
-> ## The Docker official documentation is helpful!
-> There is lots of great documentation at <https://docs.docker.com/>, for example, detailed reference material and tutorials covering the use of the commands mentioned above.
-{: .callout}
-
-### Conclusion
-
-You have now successfully acquired a Docker image file to your computer,
-and have created a Docker container from it.
-While this already effects a reproducible computational environment,
-the image contents are not under your control, so we look at this topic,
-after a quick discussion about the Docker Hub.
+Now the result of `docker image ls` should no longer include the `hello-world` image.
 
 {% include links.md %}
 

--- a/_episodes/04b-managing-containers.md
+++ b/_episodes/04b-managing-containers.md
@@ -1,9 +1,9 @@
 ---
-title: "Creating containers"
+title: "Exploring and Running Containers"
 teaching: 10
 exercises: 0
 questions:
-- "How do I get Docker to perform computation?"
+- "How do I interact with a Docker container on my computer?"
 objectives:
 - "Demonstrate how to create an instance of a container from an image."
 - "Explain how to list (container) images on your laptop."
@@ -15,85 +15,6 @@ keypoints:
 - "The `docker container` command lists containers that have been created."
 ---
 
-### Creating a "hello world" container
-
-> ## Reminder of terminology: images and containers
-> - Recall that a container "image" is the template from which particular instances of containers will be created.
-{: .callout}
-
-One of the simplest Docker container images just allows you to create containers that print a welcome message.
-
-To create and run containers from named Docker images you use the `docker run` command. Open a shell window if you do not already have one open and try the following `docker run` invocation. Note that it does not matter what your current working directory is.
-~~~
-$ docker run hello-world
-~~~
-{: .language-bash}
-~~~
-Unable to find image 'hello-world:latest' locally
-latest: Pulling from library/hello-world
-1b930d010525: Pull complete
-Digest: sha256:2557e3c07ed1e38f26e389462d03ed943586f744621577a99efb77324b0fe535
-Status: Downloaded newer image for hello-world:latest
-
-Hello from Docker!
-This message shows that your installation appears to be working correctly.
-
-To generate this message, Docker took the following steps:
- 1. The Docker client contacted the Docker daemon.
- 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-    (amd64)
- 3. The Docker daemon created a new container from that image which runs the
-    executable that produces the output you are currently reading.
- 4. The Docker daemon streamed that output to the Docker client, which sent it
-    to your terminal.
-
-To try something more ambitious, you can run an Ubuntu container with:
- $ docker run -it ubuntu bash
-
-Share images, automate workflows, and more with a free Docker ID:
- https://hub.docker.com/
-
-For more examples and ideas, visit:
- https://docs.docker.com/get-started/
-~~~
-{: .output}
-
-Now try to run the above command again, and observe the difference in the output.
-
-The message from "Hello from Docker!" is what's produced by instances of the hello-world container. It should be identical every time you make an instance of the hello-world container and run it.
-
- The first time you saw some initial output from the Docker command itself:
-~~~
-Unable to find image 'hello-world:latest' locally
-latest: Pulling from library/hello-world
-1b930d010525: Pull complete
-Digest: sha256:2557e3c07ed1e38f26e389462d03ed943586f744621577a99efb77324b0fe535
-Status: Downloaded newer image for hello-world:latest
-~~~
-{: .output}
-
-What this says is that your laptop didn't have its own local copy of the hello-world container's image.
-
-Docker then connected to the Docker Hub to find and download the (container) image with that name.
-
-The message notes information about the Docker Hub website, but we'll return to that in the next episode.
-
-The "digest" is a secure fingerprint (a "hash") of the particular version of the container image that you now have... (Although of course the usefulness of that hash is minimal if you don't know what to compare it to!)
-
-### Where did that "hello-world" container image get stored?
-
-The `docker image` command is used to list and modify Docker images.
-You can find out what container images you have local copies of using the following command ("ls" is short for "list"):
-~~~
-$ docker image ls
-~~~
-{: .language-bash}
-~~~
-REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
-hello-world            latest              fce289e99eb9        4 weeks ago         1.84kB
-~~~
-{: .output}
-(Actually, I had some additional images on my laptop that I've removed from the above, and in live demo I'm likely to end up displaying a great many more lines!)
 
 If you need to reclaim space, you will need to remove image files.
 On macOS and Windows, when you uninstall the overall Docker software, it should have the effect of removing all of your image files, although I have not explicitly tested this.
@@ -271,7 +192,6 @@ and have created a Docker container from it.
 While this already effects a reproducible computational environment,
 the image contents are not under your control, so we look at this topic,
 after a quick discussion about the Docker Hub.
-
 
 {% include links.md %}
 

--- a/_episodes/04b-managing-containers.md
+++ b/_episodes/04b-managing-containers.md
@@ -126,7 +126,7 @@ Deleted Containers:
 
 ## Removing images, for real this time
 
-Now that we've removed any potentially running containers, we can try again to
+Now that we've removed any potentially running or stopped containers, we can try again to
 delete the `hello-world` **image**.
 
 ~~~


### PR DESCRIPTION
- moving container management (ps, rm, etc. ) to its own episode, later. 
- adding material on running containers interactively, and with your own commands. You can't use `hello world` for this, so I've chosen `ubuntu`. Happy to use something else as needed. 

Not completely sold on yet: `docker pull` and then `docker run`. Maybe do `docker run hello-world` and then talk about `docker pull` when pulling 2nd container of choice? Or skip `hello world` altogether? 

Also, have NO idea if that table formatting is correct. That may be worth doing in html...

TO DO: 
- clean up formatting everywhere
- fix objectives/questions/keypoints
