### PR TITLE
Address alpine issues and credentials security

### DIFF
--- a/_episodes/02-meet-docker.md
+++ b/_episodes/02-meet-docker.md
@@ -48,6 +48,13 @@ Login Succeeded
 
 The `Login Succeeded` message means that your `docker` command line tool is ready to access the Docker Hub. We will return to discussion of the Docker Hub soon...
 
+> ## A note about security
+>
+> On most systems `docker login` stores your credentials in plain-text in a text file in your computer.
+> If you use a shared computer or you'd rather not store your credentials in plain-text, you might want to consider using a [docker credential helper](https://github.com/docker/docker-credential-helpersworry).
+> These will connect docker with password or keychain managers that will allow you to store your credentials securely.
+{: .callout}
+
 {% include links.md %}
 
 {% comment %}

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -151,7 +151,7 @@ $ docker run alpine
 ~~~
 {: .language-bash}
 
-If you never used the *alpine* docker image on your computer, docker told you that it couldn't find the image and had to download it fresh.
+If you never used the *alpine* docker image on your computer, docker probably printed a message that it couldn't find the image and had to download it.
 If you did the download before, the command will probably show no output. That's because this particular container is designed for you to
 provide commands yourself. Try running this instead:
 

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -151,7 +151,8 @@ $ docker run alpine
 ~~~
 {: .language-bash}
 
-Probably nothing! That's because this particular container is designed for you to
+If you never used the *alpine* docker image on your computer, docker told you that it couldn't find the image and had to download it fresh.
+If you did the download before, the command will probably show no output. That's because this particular container is designed for you to
 provide commands yourself. Try running this instead:
 
 ~~~
@@ -187,6 +188,7 @@ immediately shut down the container. But what if we wanted to keep the container
 running so we could log into it and test drive more commands? The way to
 do this is by adding the interactive flag `-it` to the `docker run` command and
 by providing a shell (usually `bash` or `sh`) as our command.
+The alpine docker image doesn't include `bash` so we need to use `sh`.
 
 ~~~
 $ docker run -it alpine sh

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -152,7 +152,7 @@ $ docker run alpine
 {: .language-bash}
 
 If you never used the *alpine* docker image on your computer, docker probably printed a message that it couldn't find the image and had to download it.
-If you did the download before, the command will probably show no output. That's because this particular container is designed for you to
+If you used the alpine image before, the command will probably show no output. That's because this particular container is designed for you to
 provide commands yourself. Try running this instead:
 
 ~~~

--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -155,12 +155,12 @@ Probably nothing! That's because this particular container is designed for you t
 provide commands yourself. Try running this instead:
 
 ~~~
-$ docker run alpine cat /proc/version
+$ docker run alpine cat /etc/os-release
 ~~~
 {: .language-bash}
 
-You should see the output of the `cat /proc/version` command, which prints out
-the version of Linux that this container is using.
+You should see the output of the `cat /etc/os-release` command, which prints out
+the version of Alpine Linux that this container is using and a few additional bits of information.
 
 > ## Hello World, Part 2
 > Can you run the container and make it print a "hello world" message?
@@ -214,7 +214,7 @@ That's because you're now inside the running container! Try these commands:
 * `ls`
 * `whoami`
 * `echo $PATH`
-* `cat /proc/version`
+* `cat /etc/os-release`
 
 All of these are being run from inside the running container, so you'll get information
 about the container itself, instead of your computer. To finish using the container,


### PR DESCRIPTION
Motivation for the changes:

1. The alpine commands were not producing the expected result.
2. `/proc/version` shows the identification of my host system instead of the docker container. Likely because `/proc` is partially mounted in the container.
3. `docker login` stores credentials unencrypted so adding a callout with a set of "better options" if one worries about this.