### PR TITLE
changes wording and examples slightly

### DIFF
--- a/_episodes/02-meet-docker.md
+++ b/_episodes/02-meet-docker.md
@@ -1,7 +1,7 @@
 ---
 title: "Introducing the Docker command line"
 teaching: 10
-exercises: 5
+exercises: 0
 questions:
 - "How do I interact with Docker?"
 objectives:

--- a/_episodes/02-meet-docker.md
+++ b/_episodes/02-meet-docker.md
@@ -56,7 +56,7 @@ $ docker container ls
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ~~~
 {: .output}
-(The command `docker info` will achieve a similar end. but produces a larger amount of output.)
+(The command `docker info` will achieve a similar end but produces a larger amount of output.)
 
 However, if you instead get a message similar to the following
 ~~~

--- a/_episodes/02-meet-docker.md
+++ b/_episodes/02-meet-docker.md
@@ -1,59 +1,67 @@
 ---
 title: "Introducing the Docker command line"
 teaching: 10
-exercises: 0
+exercises: 5
 questions:
 - "How do I interact with Docker?"
 objectives:
 - "Explain how to check that Docker is installed and is ready to use."
 - "Demonstrate some initial Docker command line interactions."
 keypoints:
-- "A toolbar icon indicates that Docker is ready to use containers."
+- "A toolbar icon indicates that Docker is ready to use."
 - "You will typically interact with Docker using the command line."
 ---
 ### Docker command line
 
-Start the Docker application that you installed in working through the setup instructions for this session. Note that this might not be necessary if your laptop is running Linux.
+Start the Docker application that you installed in working through the setup instructions for this session. Note that this might not be necessary if your laptop is running Linux or if the installation added the Docker application to your startup process. 
 
-The Docker application will usually provide a way for you to log in using the application's menu (macOS) or systray icon (Windows). This will require you to use your Docker Hub username and your password.
-
-> ## Determining your Docker Hub username
-> If you no longer recall your Docker Hub username, e.g., because you have been logging into the Docker Hub using your email address, you can find out what it is through the steps:
-> - Open <http://hub.docker.com/> in a web browser window
-> - Sign-in using your email and password (don't tell us what it is)
-> - In the top-right of the screen you will see your username.
+> ## You may need to login to Dockerhub
+> The Docker application will usually provide a way for you to log in to the Dockerhub using the application's menu (macOS) or systray
+> icon (Windows) and it is usually convenient to do this when the application starts. This will require you to use your Docker Hub
+> username and your password. We will not actually require access to Dockerhub until later in the course but if you can login now,
+> you should do so.
 {: .callout}
 
-Now open a shell window, and run the following command in your shell to check that Docker is installed. I have appended the output that I see on my Mac, but the specific version is unlikely to matter much: it certainly does not have to precisely match mine.
+> ## Determining your Docker Hub username
+> If you no longer recall your Docker Hub username, e.g., because you have been logging into the Docker Hub using your email address,
+> you can find out what it is through the steps:
+> - Open <http://hub.docker.com/> in a web browser window
+> - Sign-in using your email and password (don't tell us what it is)
+> - In the top-right of the screen you will see your username
+{: .callout}
+
+Once your Docker application is running, open a shell (terminal) window, and run the following command to check that Docker is
+installed and the command line tools are working correctly. I have appended the output that I see on my Mac, but the specific
+version is unlikely to matter much: it certainly does not have to precisely match mine.
 ~~~
 $ docker --version
 ~~~
 {: .language-bash}
 ~~~
-Docker version 18.09.1, build 4c52b90
+Docker version 19.03.5, build 633a0ea
 ~~~
 {: .output}
 
-Ensure that your command line `docker` commands are able to reach the Docker Hub by running the following command:
+The above command has not actually relied on the part of Docker that runs lightweight virtual machines being operational. Somewhat stretching a physical analogy, you can think of the above Docker command having been instructions to the cranes on a hypothetical shipping dock, but we haven't actually checked if the container ship we want to interact with is present yet. A command that checks that the virtual machine host is running is the Docker container list command (we cover this command in more detail later in the course).
+
+Without explaining the details, output on a newly installed system would likely be:
 ~~~
-$ docker login
+$ docker container ls
 ~~~
 {: .language-bash}
 ~~~
-Authenticating with existing credentials...
-Login Succeeded
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ~~~
 {: .output}
-(I wasn't prompted for authentication details, if you are, then you need to use your Docker Hub username and password.)
+(The command `docker info` will achieve a similar end. but produces potentially daunting volumes of output.)
 
-The `Login Succeeded` message means that your `docker` command line tool is ready to access the Docker Hub. We will return to discussion of the Docker Hub soon...
+However, if you instead get a message similar to the following
+~~~
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+~~~
+{: .output}
 
-> ## A note about security
->
-> On most systems `docker login` stores your credentials in plain-text in a text file in your computer.
-> If you use a shared computer or you'd rather not store your credentials in plain-text, you might want to consider using a [docker credential helper](https://github.com/docker/docker-credential-helpersworry).
-> These will connect docker with password or keychain managers that will allow you to store your credentials securely.
-{: .callout}
+then you need to check that you have started the Docker Desktop, Docker Engine, or however else you worked through the setup instructions.
 
 {% include links.md %}
 

--- a/_episodes/02-meet-docker.md
+++ b/_episodes/02-meet-docker.md
@@ -15,8 +15,8 @@ keypoints:
 
 Start the Docker application that you installed in working through the setup instructions for this session. Note that this might not be necessary if your laptop is running Linux or if the installation added the Docker application to your startup process. 
 
-> ## You may need to login to Dockerhub
-> The Docker application will usually provide a way for you to log in to the Dockerhub using the application's menu (macOS) or systray
+> ## You may need to login to Docker Hub
+> The Docker application will usually provide a way for you to log in to the Docker Hub using the application's menu (macOS) or systray
 > icon (Windows) and it is usually convenient to do this when the application starts. This will require you to use your Docker Hub
 > username and your password. We will not actually require access to Dockerhub until later in the course but if you can login now,
 > you should do so.
@@ -42,7 +42,10 @@ Docker version 19.03.5, build 633a0ea
 ~~~
 {: .output}
 
-The above command has not actually relied on the part of Docker that runs lightweight virtual machines being operational. Somewhat stretching a physical analogy, you can think of the above Docker command having been instructions to the cranes on a hypothetical shipping dock, but we haven't actually checked if the container ship we want to interact with is present yet. A command that checks that the virtual machine host is running is the Docker container list command (we cover this command in more detail later in the course).
+The above command has not actually relied on the part of Docker that runs containers, just that Docker
+is installed and you can access it correctly from the command line.
+
+A command that checks that Docker is working correctly is the `docker container list` command (we cover this command in more detail later in the course).
 
 Without explaining the details, output on a newly installed system would likely be:
 ~~~
@@ -53,7 +56,7 @@ $ docker container ls
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ~~~
 {: .output}
-(The command `docker info` will achieve a similar end. but produces potentially daunting volumes of output.)
+(The command `docker info` will achieve a similar end. but produces a larger amount of output.)
 
 However, if you instead get a message similar to the following
 ~~~


### PR DESCRIPTION
First PR from the updated version of this lesson that @jcohen02 and myself ran online in July 2020. This one does not have many changes, just some minor rewording. The example command used to check if Docker is running correct has been changed from `docker login` to `docker container ls` to avoid describing DockerHub at this point and to link with the initial commands that used in the next episode.
