### PR TITLE
Remove inconsistency in use of -it flags in advanced containers.

### DIFF
--- a/_episodes/05b-advanced-containers.md
+++ b/_episodes/05b-advanced-containers.md
@@ -320,7 +320,7 @@ $ docker run alpine-sum:v2 12 13 14
 > that does only sums, but you need an interactive shell to examine
 > the container:
 > ~~~
-> $ docker run -ti alpine-sum:v2 /bin/sh
+> $ docker run -it alpine-sum:v2 /bin/sh
 > ~~~
 > {: .language-bash}
 > will yield
@@ -330,7 +330,7 @@ $ docker run alpine-sum:v2 12 13 14
 > {: .output}
 > You need to override the `ENTRYPOINT`-statement in the image like so:
 > ~~~
-> $ docker run -ti --entrypoint /bin/sh alpine-sum:v2
+> $ docker run -it --entrypoint /bin/sh alpine-sum:v2
 > ~~~
 > {: .language-bash}
 {: .callout}


### PR DESCRIPTION
Removes inconsistency when specifying the `-i` and `-t` flags to docker run in the "_Overriding the ENTRYPOINT_" section of `05b-advanced-containers.md`. This is referenced elsewhere as `-it` which is the general convention used to specify these flags.

As highlighted in issue #68 (thanks @markgdawson), there are a couple of instances where `-ti` has been used. These are fixed by this PR.