### PR TITLE
Updating instructor notes and lesson front page re docker changes (Fixes #87)

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -73,7 +73,7 @@ and access to resources such as files and communications networks in a uniform m
 
 ### What is a Container? What is Docker?
 
-Docker is a tool that allows you to build what are called "containers." It's 
+[Docker][Docker] is a tool that allows you to build what are called "containers." It's 
 not the only tool that can create containers, but is the one we've chosen for 
 this workshop. But what *is* a container? 
 

--- a/_episodes/07-containers-for-continuous-integration.md
+++ b/_episodes/07-containers-for-continuous-integration.md
@@ -14,7 +14,7 @@ The website for this lesson is generated mechanically, based on a set of files t
 In your shell window, in your `docker-intro` create a new directory `build-website` and `cd` into it. We will later be expanding a ZIP file into this directory later.
 
 Now open a web browser window and:
-1. Navigate to the GitHub repository that contains the files for this session, at <https://github.com/carpentries-incubator/docker-introduction/>;
+1. Navigate to the [GitHub repository][docker-introduction repository] that contains the files for this session;
 2. Click the green "Clone or download" button on the right-hand side of the page;
 3. Click "Download ZIP".
 4. The downloaded ZIP file should contain one directory named `docker-introduction-gh-pages`.

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -4,26 +4,22 @@ title: "Instructor Notes"
 
 ## Before Teaching This Lesson
 
-[Docker] and its associated tools are under ongoing rapid development. Things
+[Docker][Docker] and its associated tools are under ongoing rapid development. Things
 change regularly with version updates and new tools for interacting with
 Docker and running containers on different platforms.
 
 In particular, there can be differences between macOS, Windows and Linux
 platforms. Updates and changes introduced in Docker releases are highlighted
-in the [Docker release notes].
+in the [Docker release notes][Docker release notes].
 
 _You are strongly advised to run through the lesson content prior to running
 the lesson to ensure that everything works as expected._
 
-If you experience any issues, please [open an issue] in the lesson repository
-describing the problem and platform(s) affected. The lesson maintainers will
+If you experience any issues, please [open an issue][open a lesson issue] in the lesson
+repository describing the problem and platform(s) affected. The lesson maintainers will
 aim to resolve the issue as soon as possible but we also welcome the opening
 of pull requests (linked to issues) that resolve anything that doesn't work as
 expected with the lesson content.
-
-[Docker]: https://www.docker.com/
-[Docker release notes]: https://docs.docker.com/release-notes/
-[open an issue]: https://github.com/carpentries-incubator/docker-introduction/issues/new
 
 ## Miscellaneous Tips
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -2,6 +2,29 @@
 title: "Instructor Notes"
 ---
 
+## Before Teaching This Lesson
+
+[Docker] and its associated tools are under ongoing rapid development. Things
+change regularly with version updates and new tools for interacting with
+Docker and running containers on different platforms.
+
+In particular, there can be differences between macOS, Windows and Linux
+platforms. Updates and changes introduced in Docker releases are highlighted
+in the [Docker release notes].
+
+_You are strongly advised to run through the lesson content prior to running
+the lesson to ensure that everything works as expected._
+
+If you experience any issues, please [open an issue] in the lesson repository
+describing the problem and platform(s) affected. The lesson maintainers will
+aim to resolve the issue as soon as possible but we also welcome the opening
+of pull requests (linked to issues) the resolve anything that doesn't work as
+expected with the lesson content.
+
+[Docker]: https://www.docker.com/
+[Docker release notes]: https://docs.docker.com/release-notes/
+[open an issue]: https://github.com/carpentries-incubator/docker-introduction/issues/new
+
 ## Miscellaneous Tips
 
 * **Timing**: As written, there's way more than 3 hours of material in this lesson.

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -18,7 +18,7 @@ the lesson to ensure that everything works as expected._
 If you experience any issues, please [open an issue] in the lesson repository
 describing the problem and platform(s) affected. The lesson maintainers will
 aim to resolve the issue as soon as possible but we also welcome the opening
-of pull requests (linked to issues) the resolve anything that doesn't work as
+of pull requests (linked to issues) that resolve anything that doesn't work as
 expected with the lesson content.
 
 [Docker]: https://www.docker.com/

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,0 +1,4 @@
+[docker-introduction repository]: https://github.com/carpentries-incubator/docker-introduction
+[open a lesson issue]: https://github.com/carpentries-incubator/docker-introduction/issues/new
+[Docker]: https://www.docker.com/
+[Docker release notes]: https://docs.docker.com/release-notes/

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,4 +1,4 @@
-[docker-introduction repository]: https://github.com/carpentries-incubator/docker-introduction
-[open a lesson issue]: https://github.com/carpentries-incubator/docker-introduction/issues/new
 [Docker]: https://www.docker.com/
 [Docker release notes]: https://docs.docker.com/release-notes/
+[docker-introduction repository]: https://github.com/carpentries-incubator/docker-introduction
+[open a lesson issue]: https://github.com/carpentries-incubator/docker-introduction/issues/new

--- a/index.md
+++ b/index.md
@@ -40,10 +40,8 @@ After completing this session you should:
 > inconsistencies can occur.
 > 
 > If you spot inconsistencies or encounter any problems, please do report them
-> by [opening an issue] in the [GitHub repository] for this lesson.
-> 
-> [opening an issue]: https://github.com/carpentries-incubator/docker-introduction/issues/new
-> [GitHub repository]: https://github.com/carpentries-incubator/docker-introduction
+> by [opening an issue][open a lesson issue] in the [GitHub repository][docker-introduction repository] 
+> for this lesson.
 {: .callout}
 
 ## Learner profiles

--- a/index.md
+++ b/index.md
@@ -29,6 +29,23 @@ After completing this session you should:
 > If you are looking for a lesson on using *singularity* containers (instead of Docker), see this lesson:
 > * [Reproducible Computational Environments Using Containers: Introduction to Singularity](https://carpentries-incubator.github.io/singularity-introduction/)
 
+> ## A note about Docker
+>
+> Docker is a mature, robust and very widely used application. Nonetheless,
+> it is still under extensive development. New versions are released regularly
+> often containing a range of updates and new features.
+>
+> While we do our best to ensure that this lesson remains up to date and the
+> descriptions and outputs shown match what you will see on your own computer,
+> inconsistencies can occur.
+> 
+> If you spot inconsistencies or encounter any problems, please do report them
+> by [opening an issue] in the [GitHub repository] for this lesson.
+> 
+> [opening an issue]: https://github.com/carpentries-incubator/docker-introduction/issues/new
+> [GitHub repository]: https://github.com/carpentries-incubator/docker-introduction
+{: .callout}
+
 ## Learner profiles
 
 To help give an idea of the target audience for this lesson we have included 

--- a/setup.md
+++ b/setup.md
@@ -7,7 +7,7 @@ Please seek help at the start of the lesson if you have not been able to establi
 
 ### Files to download
 
-Download the [`docker-intro.zip`]({{ page.root }}/files/docker-intro.zip) file. _This file can alternatively be downloaded from the `files` directory in the [docker-introduction GitHub repository](https://github.com/carpentries-incubator/docker-introduction/)_.
+Download the [`docker-intro.zip`]({{ page.root }}/files/docker-intro.zip) file. _This file can alternatively be downloaded from the `files` directory in the [docker-introduction GitHub repository][docker-introduction repository]_.
 
 Move the downloaded file to your Desktop and unzip it. It should unzip to a folder called `docker-intro`. 
 


### PR DESCRIPTION
This PR addresses issue #87, adding some text to the instructor notes in a new section "_Before teaching this lesson_" and a callout to the index page highlighting that differences can occur between the information shown in the lesson and the actual output/interface provided by Docker. Both new blocks of text invite either instructors or participants to highlight any problems they notice through opening a new issue.