### PR TITLE
Resolve Theme Error in Jekyll Docker deployment (Ep.7)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -102,4 +102,4 @@ exclude:
 # Turn on built-in syntax highlighting.
 highlighter: rouge
 
-remote_theme: carpentries/carpentries-theme
+remote_theme: carpentries/carpentries-theme@main


### PR DESCRIPTION
In investigating #74, @drakeasberry and I discovered an issue with Episode 7, where running "the containers used in generating this lesson" gave the following error: `Jekyll::RemoteTheme::DownloadError`

As a fix, we now point Jekyll `remote_theme` (a parameter in `_config.yml`) to the main branch of the Carpentries GH pages theme.

#69 can be closed. This issue was resolved in [this commit](https://github.com/carpentries-incubator/docker-introduction/commit/d65409c189bec6d115318608c57cd6078f3a647f)

#74 can also be closed. This is the same issue that was resolved in the commit above

closes #74 #69 
