### PR TITLE
Creating the "choose your own example(s)" episode

### DIFF
--- a/_episodes/03-running-containers.md
+++ b/_episodes/03-running-containers.md
@@ -186,8 +186,8 @@ command and they will execute inside the running container.
 In all the examples above, Docker has started the container, run a command, and then
 immediately shut down the container. But what if we wanted to keep the container
 running so we could log into it and test drive more commands? The way to
-do this is by adding the interactive flag `-it` 
-flag `-t` to the `docker run` command and provide a shell (`bash`,`sh`, etc.) 
+do this is by adding the interactive flag `-it`
+flag `-t` to the `docker run` command and provide a shell (`bash`,`sh`, etc.)
 as our command. The alpine docker image doesn't include `bash` so we need to use `sh`.
 
 ~~~
@@ -198,8 +198,8 @@ $ docker run -it alpine sh
 > ## Technically...
 >
 > Technically, the interactive flag is just `-i` - the extra `-t` (combined
-> as `-it` above) is the "pseudo-TTY" option, a fancy term that means a text interface. 
-> This allows you to connect to a shell, like `bash`, using a command line. Since you usually 
+> as `-it` above) is the "pseudo-TTY" option, a fancy term that means a text interface.
+> This allows you to connect to a shell, like `bash`, using a command line. Since you usually
 > want to have a command line when running interactively, it makes sense to use the two together.
 {: .callout}
 
@@ -229,8 +229,14 @@ just type `exit`.
 
 > ## Practice Makes Perfect
 > Can you find out the version of Linux installed on the `busybox` container?
-> Can you find the `busybox` program? What does it do? (Hint: passing `--help`
+> (Hint: If you search online, you'll find that there are a few different ways
+> to find out what version of Linux a computer or container is running. Because
+> the `busybox` container is very simplified, you'll want to use a command that prints out
+> the contents of the file `/proc/version`.)
+>
+> Can you also find the `busybox` program? What does it do? (Hint: try passing `--help`
 > to almost any command will give you more information.)
+>
 >
 > > ## Solution 1 - Interactive
 > >

--- a/_episodes/07-docker-image-examples.md
+++ b/_episodes/07-docker-image-examples.md
@@ -18,15 +18,15 @@ You may choose one or more of the following examples to practice using container
 ## Jekyll Website Example
 
 In this [Jekyll Website example](../_extras/e02-jekyll-lesson-example), you can practice
-rendering this lesson website locally using Docker and a Jekyll a container image.
-This example helps avoid a complicated software install by using a container image.
+rendering this lesson website on your computer using Jekyll in a Docker container.
+Rendering the website in a container avoids a complicated software installation; instead of installing Jekyll and all the other tools needed to create the final website, all the work can be done in the container.
 
 
 ## GitHub Actions Example
 
 In this [GitHub Actions example](../_extras/e01-github-actions), you can learn more about
-continuous integration in the clound and how you can use container images with GitHub to
-automate some of your workflow.
+continuous integration in the cloud and how you can use container images with GitHub to
+automate repetitive tasks like testing code or deploying websites.
 
 <!--- Placeholder for 
 ## Geospatial Example

--- a/_episodes/07-docker-image-examples.md
+++ b/_episodes/07-docker-image-examples.md
@@ -1,0 +1,57 @@
+---
+title: "Examples of Using Container Images in Practice"
+teaching: 20
+exercises: 0
+questions:
+- "How can I use Docker for my own work?"
+objectives:
+- "Use existing container images and Docker in a research project."
+keypoints:
+- "There are many ways you might use Docker and existing container images in your research project."
+---
+
+Now that we have learned the basics of working with docker images and containers,
+let's apply what we learned to an example workflow.
+
+You may choose one or more of the following examples to practice using containers.
+
+## Jekyll Website Example
+
+In this [Jekyll Website example](../_extras/e02-jekyll-lesson-example), you can practice
+rendering this lesson website locally using Docker and a Jekyll a container image.
+This example helps avoid a complicated software install by using a container image.
+
+
+## GitHub Actions Example
+
+In this [GitHub Actions example](../_extras/e01-github-actions), you can learn more about
+continuous integration in the clound and how you can use container images with GitHub to
+automate some of your workflow.
+
+<!--- Placeholder for 
+## Geospatial Example
+
+Ask @mkuzak to make a PR to add extra for <https://github.com/escience-academy/docker-gdal-demo>
+
+-->
+
+Do you have another example of using Docker in a workflow related to your field?  Please [open a lesson issue] or [submit a pull request] to add it to this episode and the extras section of the lesson.
+
+
+{% include links.md %}
+
+{% comment %}
+<!--  LocalWords:  keypoints _episodes_rmd CODE_OF_CONDUCT.md aio.md
+ -->
+<!--  LocalWords:  CONTRIBUTING.md LICENSE.md index.md reference.md
+ -->
+<!--  LocalWords:  README.md setup.md _config.yml webserver srv
+ -->
+<!--  LocalWords:  jekyll x86_64-linux-musl favicons github.io
+ -->
+<!--  LocalWords:  links.md _episodes_rmd _config.yml endcomment
+ -->
+{% endcomment %}
+
+
+[submit a pull request]: https://github.com/carpentries-incubator/docker-introduction/pulls

--- a/_episodes/07-docker-image-examples.md
+++ b/_episodes/07-docker-image-examples.md
@@ -20,7 +20,7 @@ You may choose one or more of the following examples to practice using container
 In this [Jekyll Website example](../_extras/e02-jekyll-lesson-example), you can practice
 rendering this lesson website on your computer using Jekyll in a Docker container.
 Rendering the website in a container avoids a complicated software installation; instead of installing Jekyll and all the other tools needed to create the final website, all the work can be done in the container.
-
+Additionally, when you no longer need to render the website, you can easily and cleanly remove the software from your computer.
 
 ## GitHub Actions Example
 

--- a/_extras/e02-jekyll-lesson-example.md
+++ b/_extras/e02-jekyll-lesson-example.md
@@ -1,17 +1,31 @@
 ---
-title: "Containers used in generating this lesson"
+title: "Using Docker with Jekyll - Containers Used in Generating this Lesson"
+layout: episode
 teaching: 20
 exercises: 0
 questions:
+- "What is an example of how I might use Docker instead of installing software?"
 - "How can containers be useful to me for building websites?"
 objectives:
+- "Use an existing container image and Docker in place of a complicated install."
 - "Demonstrate how to construct a website using containers to transform a specification into a fully-presented website."
 keypoints:
+- "You can use existing container images and Docker instead of installing additional software."
 - "The generation of this lesson website can be effected using a container."
 ---
-The website for this lesson is generated mechanically, based on a set of files that specify the configuration of the site, its presentation template, and the content to go on this page. This is far more manageable than editing each webpage of the lesson separately, for example, if the page header needs to change, this change can be made in one place, and all the pages regenerated. The alternative would be needing to edit each page to repeat the change: this is not productive or suitable work for humans to do!
 
-In your shell window, in your `docker-intro` create a new directory `build-website` and `cd` into it. We will later be expanding a ZIP file into this directory later.
+As previously mentioned earlier in the lesson, Docker can be helpful for
+using software that can be difficult to install.  An example is the software
+that generates this lesson website.  The website for this lesson is generated mechanically,
+based on a set of files that specify the configuration of the site, its presentation template,
+and the content to go on this page.  When working on updates to this lesson,
+you might want to preview those changes using a local copy of the website.
+This requires installing Jekyll and depdencies such as Ruby and Gemfiles to your local computer
+which can be difficult. Instead you could use Docker and a pre-built Jekyll container 
+image.
+
+First we need to get a copy of the website to work with on your computer.
+In your shell window, in your `docker-intro` create a new directory `build-website` and `cd` into it. We will later be expanding a ZIP file into this directory later. 
 
 Now open a web browser window and:
 1. Navigate to the [GitHub repository][docker-introduction repository] that contains the files for this session;

--- a/_extras/e02-jekyll-lesson-example.md
+++ b/_extras/e02-jekyll-lesson-example.md
@@ -7,7 +7,7 @@ questions:
 - "What is an example of how I might use Docker instead of installing software?"
 - "How can containers be useful to me for building websites?"
 objectives:
-- "Use an existing container image and Docker in place of a complicated install."
+- "Use an existing container image and Docker in place of complicated software installation work."
 - "Demonstrate how to construct a website using containers to transform a specification into a fully-presented website."
 keypoints:
 - "You can use existing container images and Docker instead of installing additional software."

--- a/_extras/e02-jekyll-lesson-example.md
+++ b/_extras/e02-jekyll-lesson-example.md
@@ -21,11 +21,11 @@ based on a set of files that specify the configuration of the site, its presenta
 and the content to go on this page.  When working on updates to this lesson,
 you might want to preview those changes using a local copy of the website.
 This requires installing Jekyll and depdencies such as Ruby and Gemfiles to your local computer
-which can be difficult. Instead you could use Docker and a pre-built Jekyll container 
+which can be difficult to achieve given complexities such as needing to match specific versions of the software components. Instead you could use Docker and a pre-built Jekyll container 
 image.
 
 First we need to get a copy of the website to work with on your computer.
-In your shell window, in your `docker-intro` create a new directory `build-website` and `cd` into it. We will later be expanding a ZIP file into this directory later. 
+In your shell window, in your `docker-intro` create a new directory `build-website` and `cd` into it. We will be expanding a ZIP file into this directory later. 
 
 Now open a web browser window and:
 1. Navigate to the [GitHub repository][docker-introduction repository] that contains the files for this session;


### PR DESCRIPTION
Hi all! 

This should close #85 and it also starts the option of having multiple different workflow examples of how to use Docker images in practice.  Feedback welcome!  I'd particularly like alternate titles and any additional information that you think is needed in the new `07-docker-image-examples.md` episode.

I also left a comment placeholder for a third example from @mkuzak on gdal+jupyter.  @mkuzak would you want to put in a PR to add that example once this one is merged? I think you've got a good start of what you could add to an extra's page and then link to the `07-docker-image-examples.md` episode.

Thanks!