### PR TITLE
Add links to 10 simple dockerfile rules paper - closes #128

### DIFF
--- a/_episodes/05b-advanced-containers.md
+++ b/_episodes/05b-advanced-containers.md
@@ -13,9 +13,7 @@ keypoints:
 ---
 
 In order to create and use your own containers, you may need more information than
-our previous example. You may want to use files from outside the container, copy
-those files into the container, and just generally learn a little bit about software
-installation. This episode will cover these. Note that the examples will get gradually
+our previous example. You may want to use files from outside the container, that are not included within the container image, either by copying the files into the container, or by making them visible within the container from their existing location on your main system. You may also want to learn a little bit about how to install software within a running container or an image. This episode will look at these more advanced aspects of running or building a container. Note that the examples will get gradually
 more and more complex -- most day-to-day use of containers can be accomplished
 using the first 1--2 sections on this page.
 
@@ -23,6 +21,7 @@ using the first 1--2 sections on this page.
 
 In your shell, change to the `sum` folder in the `docker-intro` folder and look at
 the files inside.
+
 ~~~
 $ cd ~/Desktop/docker-intro/sum
 $ ls
@@ -39,6 +38,7 @@ container.
 {: .challenge}
 
 If we try running the container and Python script, what happens?
+
 ~~~
 $ docker run alice/alpine-python python3 sum.py
 ~~~
@@ -384,5 +384,10 @@ $ docker run alpine-sum:v3 sum.py 1 2 3 4
 ~~~
 {: .language-bash}
 
+> ## Best practices for writing Dockerfiles
+> Take a look at Nüst et al.'s "[_Ten simple rules for writing Dockerfiles for reproducible data science_](https://doi.org/10.1371/journal.pcbi.1008316)" \[1\] for some great examples of best practices to use when writing Dockerfiles. The [GitHub repository](https://github.com/nuest/ten-simple-rules-dockerfiles) associated with the paper also has a set of [example `Dockerfile`s](https://github.com/nuest/ten-simple-rules-dockerfiles/tree/master/examples) demonstrating how the rules highlighted by the paper can be applied.
+>
+> <small>[1] Nüst D, Sochat V, Marwick B, Eglen SJ, Head T, et al. (2020) Ten simple rules for writing Dockerfiles for reproducible data science. PLOS Computational Biology 16(11): e1008316. https://doi.org/10.1371/journal.pcbi.1008316</small>
+{: .callout}
 
 {% include links.md %}

--- a/_episodes/05b-advanced-containers.md
+++ b/_episodes/05b-advanced-containers.md
@@ -391,7 +391,10 @@ $ docker run alpine-sum:v3 sum.py 1 2 3 4
 {: .language-bash}
 
 > ## Best practices for writing Dockerfiles
-> Take a look at Nüst et al.'s "[_Ten simple rules for writing Dockerfiles for reproducible data science_](https://doi.org/10.1371/journal.pcbi.1008316)" \[1\] for some great examples of best practices to use when writing Dockerfiles. The [GitHub repository](https://github.com/nuest/ten-simple-rules-dockerfiles) associated with the paper also has a set of [example `Dockerfile`s](https://github.com/nuest/ten-simple-rules-dockerfiles/tree/master/examples) demonstrating how the rules highlighted by the paper can be applied.
+> Take a look at Nüst et al.'s "[_Ten simple rules for writing Dockerfiles for reproducible data science_](https://doi.org/10.1371/journal.pcbi.1008316)" \[1\] 
+> for some great examples of best practices to use when writing Dockerfiles. 
+> The [GitHub repository](https://github.com/nuest/ten-simple-rules-dockerfiles) associated with the paper also has a set of [example `Dockerfile`s](https://github.com/nuest/ten-simple-rules-dockerfiles/tree/master/examples) 
+> demonstrating how the rules highlighted by the paper can be applied.
 >
 > <small>[1] Nüst D, Sochat V, Marwick B, Eglen SJ, Head T, et al. (2020) Ten simple rules for writing Dockerfiles for reproducible data science. PLOS Computational Biology 16(11): e1008316. https://doi.org/10.1371/journal.pcbi.1008316</small>
 {: .callout}

--- a/_episodes/05b-advanced-containers.md
+++ b/_episodes/05b-advanced-containers.md
@@ -13,7 +13,13 @@ keypoints:
 ---
 
 In order to create and use your own containers, you may need more information than
-our previous example. You may want to use files from outside the container, that are not included within the container image, either by copying the files into the container, or by making them visible within the container from their existing location on your main system. You may also want to learn a little bit about how to install software within a running container or an image. This episode will look at these more advanced aspects of running or building a container. Note that the examples will get gradually
+our previous example. You may want to use files from outside the container, 
+that are not included within the container image, either by copying the files 
+into the container, or by making them visible within the container from their 
+existing location on your main system. You may also want to learn a little bit 
+about how to install software within a running container or an image. 
+This episode will look at these advanced aspects of running or building 
+a container. Note that the examples will get gradually
 more and more complex -- most day-to-day use of containers can be accomplished
 using the first 1--2 sections on this page.
 


### PR DESCRIPTION
Adding a callout box to the end of the [advanced containers episode (05b)](https://github.com/carpentries-incubator/docker-introduction/blob/gh-pages/_episodes/05b-advanced-containers.md) highlighting the "[_10 Simple Rules for writing Dockerfiles for reproducible data science_](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1008316) paper, as suggested in issue #128.