### PR TITLE
Add CITATION file content

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,1 +1,2 @@
-FIXME: describe how to cite this lesson.
+D. M. Eyers, S. L. R. Stevens, A. Turner, C. Koch and J. Cohen. "Reproducible computational environments using containers: Introduction to Docker".
+Version 2020.09a (4a93bd67aa), September 2020. Carpentries Incubator. https://github.com/carpentries-incubator/docker-introduction


### PR DESCRIPTION
This adds a suggested citation to the `CITATION` file which was previously empty.

This file should be updated to provide a complete [CFF](https://zenodo.org/record/1117789) file so this will need updating. However, to ensure we have some information on how to cite the repo, adding this for now.