### PR TITLE
Updates the jekyll and github-actions examples to use the newer style of docker commands

### DIFF
--- a/_extras/e01-github-actions.md
+++ b/_extras/e01-github-actions.md
@@ -114,7 +114,7 @@ First, let's download a container with pandoc installed and run it to see what t
 pandoc version is.
 
 ~~~
-docker run pandoc/core --version
+docker container run pandoc/core --version
 ~~~
 {: .source}
 ~~~
@@ -137,10 +137,10 @@ warranty, not even for merchantability or fitness for a particular purpose.
 {: .output}
 
 Now, we can run pandoc on our `README.md` file by including our current directory and
-the `README.md` file as part of the `docker run` command:
+the `README.md` file as part of the `docker container run` command:
 
 ~~~
-docker run --mount type=bind,source=${PWD},target=/tmp pandoc/core /tmp/README.md
+docker container run --mount type=bind,source=${PWD},target=/tmp pandoc/core /tmp/README.md
 ~~~
 {: .source}
 ~~~
@@ -157,7 +157,7 @@ add the `--standalone` argument to the pandoc command. Also we can redirect the 
 
 ~~~
 mkdir -p build
-docker run --mount type=bind,source=${PWD},target=/tmp pandoc/core /tmp/README.md --standalone --output=/tmp/build/index.html
+docker container run --mount type=bind,source=${PWD},target=/tmp pandoc/core /tmp/README.md --standalone --output=/tmp/build/index.html
 ~~~
 {: .source}
 ~~~

--- a/_extras/e02-jekyll-lesson-example.md
+++ b/_extras/e02-jekyll-lesson-example.md
@@ -59,7 +59,7 @@ You can now request that a container is created that will compile the files in t
 
 For macOS, Linux and PowerShell:
 ~~~
-$ docker run --rm -it --mount type=bind,source=${PWD},target=/srv/jekyll -p 127.0.0.1:4000:4000 jekyll/jekyll:3 jekyll serve
+$ docker container run --rm -it --mount type=bind,source=${PWD},target=/srv/jekyll -p 127.0.0.1:4000:4000 jekyll/jekyll:3 jekyll serve
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
Updated the docker run command in the jekyll and github-actions examples to use the modern CLI usage style as described in the lesson [here](https://carpentries-incubator.github.io/docker-introduction/meet-docker/index.html#docker-command-line-interface-cli-syntax). Have tested the PR myself.