### PR TITLE
chore(typo): Replace busybox with ubuntu

### DIFF
--- a/_episodes/docker-hub.md
+++ b/_episodes/docker-hub.md
@@ -18,9 +18,9 @@ keypoints:
 - "The naming convention for Docker container images is: `OWNER/CONTAINER_IMAGE_NAME:TAG`"
 ---
 
-In the previous episode, we ran a few different containers derived from different 
+In the previous episode, we ran a few different containers derived from different
 container images: `hello-world`, `alpine`,
-and maybe `busybox`. Where did these container images come from?  The Docker Hub!
+and maybe `ubuntu`. Where did these container images come from?  The Docker Hub!
 
 ## Introducing the Docker Hub
 

--- a/_episodes/running-containers.md
+++ b/_episodes/running-containers.md
@@ -240,19 +240,19 @@ type `exit`.
 >
 > > ## Solution 1 -- Interactive
 > >
-> > Run an interactive busybox container -- you can use `docker image pull` first, or just
+> > Run an interactive ubuntu container -- you can use `docker image pull` first, or just
 > > run it with this command:
 > > ~~~
 > > $ docker container run -it ubuntu sh
 > > ~~~
 > > {: .language-bash}
-> > 
+> >
 > > OR you can get the bash shell instead
 > > ~~~
 > > $ docker container run -it ubuntu bash
 > > ~~~
 > > {: .language-bash}
-> > 
+> >
 > > Then try, running these commands
 > >
 > > ~~~


### PR DESCRIPTION
Looks like the latest version of these lesson use the ubuntu container instead of busybox.

* For instance, ubuntu is used in the examples
* Therefore, we update the text in the relevant locations to reflect this