### PR TITLE
fix: Dockerfile command order in ENTRYPOINT example

### DIFF
--- a/_episodes/advanced-containers.md
+++ b/_episodes/advanced-containers.md
@@ -363,8 +363,8 @@ command line, use the keyword `ENTRYPOINT` in the `Dockerfile`.
 ~~~
 FROM alpine
 
-COPY sum.py /home
 RUN apk add --update python3 py3-pip python3-dev
+COPY sum.py /home
 
 # Run the sum.py script as the default command and
 # allow people to enter arguments for it


### PR DESCRIPTION
In the section titled [The Importance of Command Order in a Dockerfile](https://carpentries-incubator.github.io/docker-introduction/advanced-containers/index.html#the-importance-of-command-order-in-a-dockerfile), the text states that:

>This order is important for rebuilding and you typically will want to put your RUN commands **before** your COPY commands.
> For example, in an instance where you wanted to copy multiply.py into the container image instead of sum.py. If the COPY line came before the RUN line, it would need to rebuild the whole image. If the COPY line came second then it would use the cached RUN layer from the previous build and then only rebuild the COPY layer.

In the example that introduces the `ENTRYPOINT` command, we currently have:

```Dockerfile
RUN apk add --update python3 py3-pip python3-dev
COPY sum.py /home
```

This PR fixes the order as per the recommendation earlier in this lesson by interchanging these two lines.
