### PR TITLE
Add exercise timing

### DIFF
--- a/episodes/docker-image-examples.md
+++ b/episodes/docker-image-examples.md
@@ -1,7 +1,7 @@
 ---
 title: Examples of Using Container Images in Practice
-teaching: 20
-exercises: 0
+teaching: 10
+exercises: 15
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -1,7 +1,7 @@
 ---
 title: Introducing Containers
 teaching: 20
-exercises: 0
+exercises: 5
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives

--- a/episodes/meet-docker.md
+++ b/episodes/meet-docker.md
@@ -1,7 +1,7 @@
 ---
 title: Introducing the Docker Command Line
 teaching: 10
-exercises: 0
+exercises: 5
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives

--- a/episodes/reproduciblity.md
+++ b/episodes/reproduciblity.md
@@ -1,7 +1,7 @@
 ---
 title: 'Containers in Research Workflows: Reproducibility and Granularity'
 teaching: 20
-exercises: 0
+exercises: 5
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives


### PR DESCRIPTION
This PR adds exercise timing to the episodes that include exercises but didn't have exercise timing set previously.

For "Examples of Using Container Images in Practice" (`docker-image-examples.md`), there are no specific exercise callouts but the content suggests choosing one or more of the provided examples to practice using containers. I've therefore cut the "teaching" time to 10 minutes, assuming that the instructor will provide a brief overview of the different examples, and added 15 minutes exercise time. Perhaps it would even be better to increase this to 20 or 25 minutes? This is flexible since it depends on how much time the instructor wants to dedicate to this.

Closes #232.