### PR TITLE
Fix issue due to ubuntu-latest not containing R

### DIFF
--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -21,7 +21,9 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-latest
+    # 20245-01-01: ubuntu-latest is now 24.04 and R is not installed by default in the runner image
+    # pin to 22.04 for now. See: https://github.com/carpentries/sandpaper/issues/605
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       contents: write


### PR DESCRIPTION
As noted in the open issues:

https://github.com/carpentries/sandpaper/issues/605

and:

https://github.com/esciencecenter-digital-skills/geospatial-python/pull/128

The Github runner action in sandpaper-main.yaml needs to be pnned to Ubuntu 22.04 rather than ubuntu-latest for the lesson build process to work. This PR implements the required change.
