### PR TITLE
Update PR receive action workflow

### DIFF
--- a/.github/workflows/pr-receive.yaml
+++ b/.github/workflows/pr-receive.yaml
@@ -13,7 +13,7 @@ jobs:
   test-pr:
     name: "Record PR number"
     if: ${{ github.event.action != 'closed' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       is_valid: ${{ steps.check-pr.outputs.VALID }}
     steps:
@@ -48,7 +48,7 @@ jobs:
   build-md-source:
     name: "Build markdown source files if valid"
     needs: test-pr
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ needs.test-pr.outputs.is_valid == 'true' }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -58,10 +58,10 @@ jobs:
       MD: ${{ github.workspace }}/site/built
     steps:
       - name: "Check Out Main Branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Check Out Staging Branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: md-outputs
           path: ${{ env.MD }}


### PR DESCRIPTION
The markdown build workflow is failing on recent PRs. There seem to have been changes to this workflow in the main lesson template repo so this PR ports those changes into this repo.