### PR TITLE
Add CFF version of citation data

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,2 +1,0 @@
-D. M. Eyers, S. L. R. Stevens, A. Turner, C. Koch and J. Cohen. "Reproducible computational environments using containers: Introduction to Docker".
-Version 2020.09a (4a93bd67aa), September 2020. Carpentries Incubator. https://github.com/carpentries-incubator/docker-introduction

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,12 +17,14 @@ authors:
     family-names: Eyers
   - given-names: Sarah L. R.
     family-names: Stevens
+    orcid: 'https://orcid.org/0000-0002-7040-548X'
   - given-names: Andrew
     family-names: Turner
   - given-names: Christina
     family-names: Koch
   - given-names: Jeremy
     family-names: Cohen
+    orcid: 'https://orcid.org/0000-0003-4312-2537'
 repository-code: >-
   https://github.com/carpentries-incubator/docker-introduction
 url: >-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,52 @@
+# This template CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to replace its contents
+# with information about your lesson.
+# Remember to update this file periodically, 
+# ensuring that the author list and other fields remain accurate.
+
+cff-version: 1.2.0
+title: "Reproducible computational environments using containers: Introduction to Docker"
+message: >-
+  Please cite this lesson using the information in this file
+  when you refer to it in publications, and/or if you
+  re-use, adapt, or expand on the content in your own
+  training material.
+type: dataset
+authors:
+  - given-names: David. M.
+    family-names: Eyers
+  - given-names: Sarah L. R.
+    family-names: Stevens
+  - given-names: Andrew
+    family-names: Turner
+  - given-names: Christina
+    family-names: Koch
+  - given-names: Jeremy
+    family-names: Cohen
+repository-code: >-
+  https://github.com/carpentries-incubator/docker-introduction
+url: >-
+  https://carpentries-incubator.github.io/docker-introduction/
+abstract: >-
+  This lesson provides an introduction to the Docker and Podman
+  "container" tools. These tools support the bundling of software
+  and tools in containers that are lightweight and flexible. They
+  provide a great opportunity to support the development of
+  reproducible computational environments that are important in a
+  number of environments, including developing, running and
+  maintaining research software. Learners taking this course will
+  develop and understanding of what containers are and how to use
+  and build them. The course is undertaken using the open source
+  Podman tool but the knowledge gained is equally applicable to,
+  and transferable to, the use of Docker.
+keywords:
+  - Containers
+  - Docker
+  - Podman
+  - Reproducibility
+  - Research software
+license: CC-BY-4.0
+commit: 4a93bd67aa
+version: 2020.09a
+date-released: '2020-09-01'
+


### PR DESCRIPTION
This PR addresses issue #266.

It provides a Citation File Format (CFF) version of the citation data, replacing the original `CITATION` file with a new `CITATION.cff` file.

This has been created based on the [template](https://github.com/carpentries/workbench-template-rmd/blob/main/CITATION.cff) in the [workbench-template-rmd repo](https://github.com/carpentries/workbench-template-rmd).