### PR TITLE
Update Singularity to Apptainer in HPC section

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,8 +30,8 @@ The practical work in this lesson is primarily aimed at using Docker on your own
 
 ## Containers on HPC systems
 
-On HPC systems it is more likely that *Singularity* rather than Docker will be the available container technology.
-If you are looking for a lesson on using Singularity containers (instead of Docker), see this lesson:
+On HPC systems it is more likely that *Apptainer* (formerly Singularity) rather than Docker will be the available container technology.
+If you are looking for a lesson on using Apptainer containers (instead of Docker), see this lesson on Singularity:
 
 - [Reproducible Computational Environments Using Containers: Introduction to Singularity](https://carpentries-incubator.github.io/singularity-introduction/)
   


### PR DESCRIPTION
The Singularity project was renamed to Apptainer in 2022 https://apptainer.org/news/article-20211130/